### PR TITLE
Proposal: Allow to pass an `Htmlable` to the view getting rid of unescaped output

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -30,14 +30,20 @@
             </div>
         @endif
         <div class="ml-3 flex-1 md:flex md:justify-between">
-            <div>
-                <p class="text-sm font-medium text-custom-800 dark:text-white">
-                    {!! $title !!}
-                </p>
-                <p class="text-sm text-custom-700 dark:text-white">
-                    {!! $description !!}
-                </p>
-            </div>
+            @if($title || $description)
+                <div>
+                    @if($title)
+                        <p class="text-sm font-medium text-custom-800 dark:text-white">
+                            {{ $title }}
+                        </p>
+                    @endif
+                    @if($description)
+                        <p class="text-sm text-custom-700 dark:text-white">
+                            {{ $description }}
+                        </p>
+                    @endif
+                </div>
+            @endif
             @if($link)
                 <p class="mt-3 text-sm md:ml-6 md:mt-0 self-center">
                     <a href="{{ $link }}" {{ $linkBlank ? 'target="_blank"' : '' }} class="whitespace-nowrap font-medium text-custom-400 hover:text-custom-500">

--- a/src/Components/Concerns/HasDescription.php
+++ b/src/Components/Concerns/HasDescription.php
@@ -3,19 +3,20 @@
 namespace CodeWithDennis\SimpleAlert\Components\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasDescription
 {
-    protected Closure|string|null $description = null;
+    protected string | Htmlable | Closure | null $description = null;
 
-    public function description(Closure|string|null $description): static
+    public function description(string | Htmlable | Closure | null $description): static
     {
         $this->description = $description;
 
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getDescription(): string | Htmlable | null
     {
         return $this->evaluate($this->description);
     }

--- a/src/Components/Concerns/HasTitle.php
+++ b/src/Components/Concerns/HasTitle.php
@@ -3,19 +3,20 @@
 namespace CodeWithDennis\SimpleAlert\Components\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasTitle
 {
-    protected Closure|string|null $title = null;
+    protected string | Htmlable | Closure | null $title = null;
 
-    public function title(Closure|string|null $title): static
+    public function title(string | Htmlable | Closure | null $title): static
     {
         $this->title = $title;
 
         return $this;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(): string | Htmlable | null
     {
         return $this->evaluate($this->title);
     }


### PR DESCRIPTION
This PR allows to pass an `Htmlable` as `title` or `description` getting rid of the unescaped output in blade. 