### PR TITLE
Fix text wrapping for action labels with a space

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -46,7 +46,7 @@
                 </div>
             @endif
             @if($link || $actions)
-                <div class="flex gap-x-3 items-center">
+                <div class="flex gap-x-3 items-center whitespace-nowrap">
                     @if($link)
                         <p class="text-sm md:ml-6 md:mt-0 self-center">
                             <a href="{{ $link }}" {{ $linkBlank ? 'target="_blank"' : '' }} class="whitespace-nowrap font-medium text-custom-400 hover:text-custom-500">


### PR DESCRIPTION
This PR fixes and issue with text wrapping for action labels with a space.

Before:
![Screenshot 2024-10-05 235809](https://github.com/user-attachments/assets/50940421-ce0b-4d45-80ef-8799e1e57d5b)

After:
![Screenshot 2024-10-05 235823](https://github.com/user-attachments/assets/20f538a5-ed3a-4f6f-ad55-81eaee80cd1d)

