### PR TITLE
Add the ability to align icon and actions at the top (start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ SimpleAlert::make('example')
     ->icon('heroicon-s-users')
 ```
 
+#### Icon Vertical Alignment
+
+You can change the vertical alignment of the icon by using the `iconVerticalAlignment` method.
+
+```php
+use CodeWithDennis\SimpleAlert\Components\Infolists\SimpleAlert;
+
+SimpleAlert::make('example')
+    ->iconVerticalAlignment('start'), // possible values: start, center
+``` 
+
 ### Title
 
 You can add a title to the alert by using the `title` method.
@@ -117,6 +128,19 @@ SimpleAlert::make('example')
             ->color('info'),
     ]),
 ```
+
+#### Actions Vertical Alignment
+
+You can change the vertical alignment of the actions by using the `actionsVerticalAlignment` method.
+
+```php
+use CodeWithDennis\SimpleAlert\Components\Infolists\SimpleAlert;
+use Filament\Forms\Components\Actions;
+
+SimpleAlert::make('example')
+    ->actionsVerticalAlignment('start'), // possible values: start, center
+```
+
 
 ### Example
 

--- a/resources/views/components/simple-alert-entry.blade.php
+++ b/resources/views/components/simple-alert-entry.blade.php
@@ -1,6 +1,7 @@
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
     <x-filament-simple-alert::simple-alert
             :icon="$getIcon()"
+            :icon-vertical-alignment="$getIconVerticalAlignment()"
             :color="$getColor()"
             :title="$getTitle()"
             :description="$getDescription()"

--- a/resources/views/components/simple-alert-entry.blade.php
+++ b/resources/views/components/simple-alert-entry.blade.php
@@ -8,5 +8,7 @@
             :link="$getLink()"
             :link-label="$getLinkLabel()"
             :link-blank="$getLinkBlank()"
+{{--            :actions="$getActions()" https://github.com/CodeWithDennis/filament-simple-alert/pull/20 --}}
+            :actions-vertical-alignment="$getActionsVerticalAlignment()"
     />
 </x-dynamic-component>

--- a/resources/views/components/simple-alert-field.blade.php
+++ b/resources/views/components/simple-alert-field.blade.php
@@ -1,6 +1,7 @@
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <x-filament-simple-alert::simple-alert
             :icon="$getIcon()"
+            :icon-vertical-alignment="$getIconVerticalAlignment()"
             :color="$getColor()"
             :title="$getTitle()"
             :description="$getDescription()"
@@ -8,5 +9,6 @@
             :link-label="$getLinkLabel()"
             :link-blank="$getLinkBlank()"
             :actions="$getActions()"
+            :actions-vertical-alignment="$getActionsVerticalAlignment()"
     />
 </x-dynamic-component>

--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -31,7 +31,7 @@
     <div class="flex">
         @if($icon)
             <div @class([
-                'flex-shrink-0 self-center ltr:mr-3 rtl:ml-3',
+                'flex-shrink-0 ltr:mr-3 rtl:ml-3',
                 $iconVerticalAlignment === 'start' ? 'self-start' : 'self-center',
             ])>
                 <x-filament::icon

--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -1,8 +1,10 @@
 @props([
     'actions' => null,
+    'actionsVerticalAlignment' => 'center',
     'color' => null,
     'description' => null,
     'icon' => null,
+    'iconVerticalAlignment' => 'center',
     'link' => null,
     'linkBlank' => false,
     'linkLabel' => null,
@@ -23,7 +25,10 @@
         style="{{ $colors }}">
     <div class="flex">
         @if($icon)
-            <div class="flex-shrink-0 self-center">
+            <div @class([
+                'flex-shrink-0',
+                $iconVerticalAlignment === 'start' ? 'self-start' : 'self-center',
+            ])>
                 <x-filament::icon
                         icon="{{ $icon }}"
                         class="h-5 w-5 text-custom-400"
@@ -46,7 +51,10 @@
                 </div>
             @endif
             @if($link || $actions)
-                <div class="flex gap-x-3 items-center">
+                <div @class([
+                  'flex gap-x-3 items-center',
+                    $actionsVerticalAlignment === 'start' ? 'self-start' : 'self-center',
+                ])>
                     @if($link)
                         <p class="text-sm md:ml-6 md:mt-0 self-center">
                             <a href="{{ $link }}" {{ $linkBlank ? 'target="_blank"' : '' }} class="whitespace-nowrap font-medium text-custom-400 hover:text-custom-500">

--- a/src/Components/Concerns/HasActionVerticalAlignment.php
+++ b/src/Components/Concerns/HasActionVerticalAlignment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CodeWithDennis\SimpleAlert\Components\Concerns;
+
+use Closure;
+
+trait HasActionVerticalAlignment
+{
+    protected Closure|string|null $actionsVerticalAlignment = 'center';
+
+    public function actionsVerticalAlignment(Closure|string|null $actionsVerticalAlignment = 'center'): static
+    {
+        $this->actionsVerticalAlignment = $actionsVerticalAlignment;
+
+        return $this;
+    }
+
+    public function getActionsVerticalAlignment(): ?string
+    {
+        return $this->evaluate($this->actionsVerticalAlignment);
+    }
+}

--- a/src/Components/Concerns/HasIcon.php
+++ b/src/Components/Concerns/HasIcon.php
@@ -8,8 +8,6 @@ trait HasIcon
 {
     protected Closure|string|null $icon = null;
 
-    protected Closure|string|null $iconVerticalAlignment = null;
-
     public function icon(Closure|string $icon): static
     {
         $this->icon = $icon;
@@ -20,17 +18,5 @@ trait HasIcon
     public function getIcon(): ?string
     {
         return $this->evaluate($this->icon);
-    }
-
-    public function iconVerticalAlignment(Closure|string $iconVerticalAlignment = 'center'): static
-    {
-        $this->iconVerticalAlignment = $iconVerticalAlignment;
-
-        return $this;
-    }
-
-    public function getIconVerticalAlignment(): ?string
-    {
-        return $this->evaluate($this->iconVerticalAlignment);
     }
 }

--- a/src/Components/Concerns/HasIcon.php
+++ b/src/Components/Concerns/HasIcon.php
@@ -8,6 +8,8 @@ trait HasIcon
 {
     protected Closure|string|null $icon = null;
 
+    protected Closure|string|null $iconVerticalAlignment = null;
+
     public function icon(Closure|string $icon): static
     {
         $this->icon = $icon;
@@ -18,5 +20,17 @@ trait HasIcon
     public function getIcon(): ?string
     {
         return $this->evaluate($this->icon);
+    }
+
+    public function iconVerticalAlignment(Closure|string $iconVerticalAlignment = 'center'): static
+    {
+        $this->iconVerticalAlignment = $iconVerticalAlignment;
+
+        return $this;
+    }
+
+    public function getIconVerticalAlignment(): ?string
+    {
+        return $this->evaluate($this->iconVerticalAlignment);
     }
 }

--- a/src/Components/Concerns/HasIconVerticalAlignment.php
+++ b/src/Components/Concerns/HasIconVerticalAlignment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CodeWithDennis\SimpleAlert\Components\Concerns;
+
+use Closure;
+
+trait HasIconVerticalAlignment
+{
+    protected Closure|string|null $iconVerticalAlignment = 'center';
+
+    public function iconVerticalAlignment(Closure|string|null $iconVerticalAlignment = 'center'): static
+    {
+        $this->iconVerticalAlignment = $iconVerticalAlignment;
+
+        return $this;
+    }
+
+    public function getIconVerticalAlignment(): ?string
+    {
+        return $this->evaluate($this->iconVerticalAlignment);
+    }
+}

--- a/src/Components/Forms/SimpleAlert.php
+++ b/src/Components/Forms/SimpleAlert.php
@@ -3,9 +3,11 @@
 namespace CodeWithDennis\SimpleAlert\Components\Forms;
 
 use Closure;
+use CodeWithDennis\SimpleAlert\Components\Concerns\HasActionVerticalAlignment;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasColor;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasDescription;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasIcon;
+use CodeWithDennis\SimpleAlert\Components\Concerns\HasIconVerticalAlignment;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasLink;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasSimple;
 use CodeWithDennis\SimpleAlert\Components\Concerns\HasTitle;
@@ -16,11 +18,11 @@ class SimpleAlert extends Field
     use HasColor;
     use HasDescription;
     use HasIcon;
+    use HasIconVerticalAlignment;
     use HasLink;
     use HasSimple;
     use HasTitle;
-
-    protected Closure|string|null $actionsVerticalAlignment = null;
+    use HasActionVerticalAlignment;
 
     protected string $view = 'filament-simple-alert::components.simple-alert-field';
 
@@ -29,18 +31,6 @@ class SimpleAlert extends Field
         $this->actions = $actions;
 
         return $this;
-    }
-
-    public function actionsVerticalAlignment(Closure|string $actionsVerticalAlignment = 'center'): static
-    {
-        $this->actionsVerticalAlignment = $actionsVerticalAlignment;
-
-        return $this;
-    }
-
-    public function getActionsVerticalAlignment(): ?string
-    {
-        return $this->evaluate($this->actionsVerticalAlignment);
     }
 
     protected function setUp(): void

--- a/src/Components/Forms/SimpleAlert.php
+++ b/src/Components/Forms/SimpleAlert.php
@@ -20,6 +20,8 @@ class SimpleAlert extends Field
     use HasSimple;
     use HasTitle;
 
+    protected Closure|string|null $actionsVerticalAlignment = null;
+
     protected string $view = 'filament-simple-alert::components.simple-alert-field';
 
     public function actions(array|Closure $actions): static
@@ -27,6 +29,18 @@ class SimpleAlert extends Field
         $this->actions = $actions;
 
         return $this;
+    }
+
+    public function actionsVerticalAlignment(Closure|string $actionsVerticalAlignment = 'center'): static
+    {
+        $this->actionsVerticalAlignment = $actionsVerticalAlignment;
+
+        return $this;
+    }
+
+    public function getActionsVerticalAlignment(): ?string
+    {
+        return $this->evaluate($this->actionsVerticalAlignment);
     }
 
     protected function setUp(): void

--- a/src/Components/Forms/SimpleAlert.php
+++ b/src/Components/Forms/SimpleAlert.php
@@ -15,6 +15,7 @@ use Filament\Forms\Components\Field;
 
 class SimpleAlert extends Field
 {
+    use HasActionVerticalAlignment;
     use HasColor;
     use HasDescription;
     use HasIcon;
@@ -22,7 +23,6 @@ class SimpleAlert extends Field
     use HasLink;
     use HasSimple;
     use HasTitle;
-    use HasActionVerticalAlignment;
 
     protected string $view = 'filament-simple-alert::components.simple-alert-field';
 


### PR DESCRIPTION
This PR adds the ability to align the icon and actions to either the top (start) or center.

Aligned center (default):
![Screenshot 2024-10-06 000107](https://github.com/user-attachments/assets/347bf17b-4e80-437b-baf4-6c34fad88110)


Aligned top (start):
![Screenshot 2024-10-06 000117](https://github.com/user-attachments/assets/9b801e90-ad00-4309-a721-a12a69913710)
