### PR TITLE
Extend icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,17 @@ SimpleAlert::make('example')
 
 ### Icon
 
-By default, all simple alerts will have an icon. If you would like to change the icon, you can use the `icon` method.
+If you would like to use an icon, you can use the `icon` method.
 
 ```php
 use CodeWithDennis\SimpleAlert\Components\Infolists\SimpleAlert;
+//use Illuminate\Support\HtmlString;
 
 SimpleAlert::make('example')
     ->color('purple')
     ->icon('heroicon-s-users')
+//->icon(new HtmlString('🤓'))
+//->icon(new HtmlString(Blade::render('my-custom-icon-component')))
 ```
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SimpleAlert::make('example')
 
 ### Icon
 
-If you would like to use an icon, you can use the `icon` method.
+By default, simple alerts come with an icon. For example, the `->danger()` method includes a `heroicon-s-x-circle` icon. If you want to use a different icon, you can use the icon method.
 
 ```php
 use CodeWithDennis\SimpleAlert\Components\Infolists\SimpleAlert;

--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -16,6 +16,7 @@
     $colors = \Illuminate\Support\Arr::toCssStyles([
            get_color_css_variables($color, shades: [50, 100, 400, 500, 600, 700, 800]),
    ]);
+
 @endphp
 
 <div
@@ -27,14 +28,14 @@
         style="{{ $colors }}">
     <div class="flex">
         @if($icon)
-            <div class="flex-shrink-0 self-center">
+            <div class="flex-shrink-0 self-center mr-3">
                 <x-filament::icon
-                        icon="{{ $icon }}"
+                        :icon="$icon"
                         class="h-5 w-5 text-custom-400"
                 />
             </div>
         @endif
-        <div class="ml-3 items-center flex-1 md:flex md:justify-between">
+        <div class="items-center flex-1 md:flex md:justify-between">
             @if($title || $description)
                 <div>
                     @if($title)

--- a/src/Components/Concerns/HasIcon.php
+++ b/src/Components/Concerns/HasIcon.php
@@ -3,19 +3,20 @@
 namespace CodeWithDennis\SimpleAlert\Components\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasIcon
 {
-    protected Closure|string|null $icon = null;
+    protected string|Htmlable|Closure|null $icon = null;
 
-    public function icon(Closure|string $icon): static
+    public function icon(string|Htmlable|Closure|null $icon): static
     {
         $this->icon = $icon;
 
         return $this;
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): string|Htmlable|null
     {
         return $this->evaluate($this->icon);
     }


### PR DESCRIPTION
This PR adds support for `Htmlable` for icons.

## Heroicon
![Screenshot 2024-10-11 211027](https://github.com/user-attachments/assets/1ab6c331-9432-4d1e-9df9-b5499aecb111)
```php
SimpleAlert::make('alert')
  ->title('Cool Title 👍')
  ->description('This is a cool description')
  ->color('danger')
  ->icon('heroicon-s-information-circle')
```
## No icon
![Screenshot 2024-10-11 205219](https://github.com/user-attachments/assets/406b7edd-426d-4353-b283-b2d5b5f8a1db)
```php
SimpleAlert::make('alert')
  ->title('Cool Title 👍')
  ->description('This is a cool description')
  ->color('danger')
```

## Emoji
![Screenshot 2024-10-11 205044](https://github.com/user-attachments/assets/27a98cc9-604e-49af-991c-02269ac7f263)

```php
SimpleAlert::make('alert')
  ->title('Cool Title 👍')
  ->description('This is a cool description')
  ->color('danger')
  ->icon(new HtmlString('🤪'))
```

## `Htmlable`
![Screenshot 2024-10-11 205144](https://github.com/user-attachments/assets/3c8f934a-9bcf-4a0f-ae21-125321e2f4d2)
```php
SimpleAlert::make('alert')
  ->title('Cool Title 👍')
  ->description('This is a cool description')
  ->color('danger')
  ->icon(new HtmlString(Blade::render('my-custom-icon'))),
```


