### PR TITLE
Use component attributes

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -21,10 +21,10 @@
 @endphp
 
 <div x-data="{}"
-     @class([
-       'filament-simple-alert rounded-md bg-custom-50 p-4 dark:bg-custom-400/10',
-       'ring-1 ring-custom-100 dark:ring-custom-500/70' => $border,
-     ])
+     {{ $attributes->class([
+         'filament-simple-alert rounded-md bg-custom-50 p-4 dark:bg-custom-400/10',
+         'ring-1 ring-custom-100 dark:ring-custom-500/70' => $border,
+     ]) }}
      style="{{ $colors }}">
     <div class="flex gap-3">
         @if($icon)


### PR DESCRIPTION
Allow for attributes to be passed when used as blade component.

E.g
```
<x-filament-simple-alert::simple-alert
    :color="AlertTypeEnum::Warning->value"
    :actions="[$this->saveAction]"
    icon="heroicon-o-exclamation-triangle"
    x-show="formChanged"
    class="mb-5"
>
    <x-slot:description>
         You have unsaved changes!
    </x-slot:description>
</x-filament-simple-alert::simple-alert>
```

Would it be worth adding `$slot` as the default description?