### PR TITLE
Update return type of getIcon method to nullable string

### DIFF
--- a/src/Components/Concerns/HasIcon.php
+++ b/src/Components/Concerns/HasIcon.php
@@ -25,7 +25,7 @@ trait HasIcon
         return $this->evaluate($this->iconAnimation)?->value ?? null;
     }
 
-    public function getIcon(): string
+    public function getIcon(): ?string
     {
         return $this->evaluate($this->icon);
     }


### PR DESCRIPTION
This pull request includes a small change to the `src/Components/Concerns/HasIcon.php` file. The change updates the return type of the `getIcon` method to allow for `null` values.