### PR TITLE
`4.x` support icon enums

### DIFF
--- a/src/Components/Concerns/HasIcon.php
+++ b/src/Components/Concerns/HasIcon.php
@@ -2,17 +2,18 @@
 
 namespace CodeWithDennis\SimpleAlert\Components\Concerns;
 
+use BackedEnum;
 use Closure;
 use CodeWithDennis\SimpleAlert\Components\Enums\IconAnimation;
 use Illuminate\Contracts\Support\Htmlable;
 
 trait HasIcon
 {
-    protected string|Htmlable|Closure|null $icon = null;
+    protected string|BackedEnum|Htmlable|Closure|null $icon = null;
 
     protected Closure|IconAnimation|null $iconAnimation = null;
 
-    public function icon(string|Htmlable|Closure|null $icon, Closure|IconAnimation|null $animation = null): static
+    public function icon(string|BackedEnum|Htmlable|Closure|null $icon, Closure|IconAnimation|null $animation = null): static
     {
         $this->icon = $icon;
         $this->iconAnimation = $animation;
@@ -25,7 +26,7 @@ trait HasIcon
         return $this->evaluate($this->iconAnimation)?->value ?? null;
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): BackedEnum|string|null
     {
         return $this->evaluate($this->icon);
     }


### PR DESCRIPTION
This pull request introduces updates to the `HasIcon` trait in `src/Components/Concerns/HasIcon.php` to enhance flexibility by supporting `BackedEnum` types for icons. The changes improve type safety and expand the range of values that can be used for icons and icon animations.

### Updates to `HasIcon` trait:

* **Support for `BackedEnum` in icon definitions**:
  - Added `BackedEnum` as a valid type for the `$icon` property and the `icon` method parameters. (`[src/Components/Concerns/HasIcon.phpR5-R16](diffhunk://#diff-aa1d2065fa873adf077a76dc3cbf3e121746b94b5765731b9a6754c614867f6fR5-R16)`)
  
* **Updated return type for `getIcon` method**:
  - Modified the return type of `getIcon` to include `BackedEnum`, allowing it to return either a string, `BackedEnum`, or `null`. (`[src/Components/Concerns/HasIcon.phpL28-R29](diffhunk://#diff-aa1d2065fa873adf077a76dc3cbf3e121746b94b5765731b9a6754c614867f6fL28-R29)`)