### PR TITLE
Replace description paragraph with a div

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -53,9 +53,9 @@
                         </p>
                     @endif
                     @if($description)
-                        <p class="text-sm text-custom-700 dark:text-white">
+                        <div class="block text-sm text-custom-700 dark:text-white">
                             {{ $description }}
-                        </p>
+                        </div>
                     @endif
                 </div>
             @endif


### PR DESCRIPTION
Fixes #50 and enables the use of paragraphs (e.g. rendering markdown) within the description of the alert.