### PR TITLE
Replace description paragraph with a div element

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -38,9 +38,9 @@
                         </p>
                     @endif
                     @if($getDescription())
-                        <p class="text-sm text-custom-700 dark:text-white">
+                        <div class="block text-sm text-custom-700 dark:text-white">
                             {{ $getDescription() }}
-                        </p>
+                        </div>
                     @endif
                 </div>
             @endif


### PR DESCRIPTION
Fixes #50 and enables the use of paragraphs (e.g. rendering markdown) within the description of the alert.