### PR TITLE
Update composer.json to support newer versions of nunomaduro/collisio…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "laravel/pint": "^1.16",
-        "nunomaduro/collision": "^7.9",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^7.9|^8.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.1",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"


### PR DESCRIPTION
Fixes issues when tryting to composer install locally 

```bash
filament-simple-alert on  4.x [!] via  v22.21.1 via 🐘 v8.4.17 
❯ composer install
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires filament/filament ^4.0|^5.0 -> satisfiable by filament/filament[v4.3.1, ..., 4.x-dev, v5.0.0-beta1, ..., 5.x-dev].
    - Root composer.json requires nunomaduro/collision ^7.9 -> satisfiable by nunomaduro/collision[v7.9.0, ..., v7.x-dev].
    - nunomaduro/collision[v7.9.0, ..., v7.10.0] require symfony/console ^6.3.4 -> satisfiable by symfony/console[v6.3.4, ..., 6.4.x-dev].
    - nunomaduro/collision v7.11.0 requires symfony/console ^6.4.12 -> satisfiable by symfony/console[v6.4.12, ..., 6.4.x-dev].
    - nunomaduro/collision[v7.12.0, ..., v7.x-dev] require symfony/console ^6.4.17 -> satisfiable by symfony/console[v6.4.17, ..., 6.4.x-dev].
    - Conclusion: don't install symfony/console v6.3.12 (conflict analysis result)
    - Conclusion: don't install symfony/console v6.4.32 (conflict analysis result)

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
``` 

#### Full disclosure

These changes were suggested by Opus 4.5. The change was tested. I was able to `composer install simple-alert` locally and symlink it to a Filament v5 local install too (v4 is to be determined yet)