### PR TITLE
fix: multiple evaluations for the same closure 

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -9,6 +9,11 @@
         'h-5 w-5 text-custom-400',
         $getIconAnimation(),
     ]);
+
+    $actions = $getActions();
+    $description = $getDescription();
+    $icon = $getIcon();
+    $title = $getTitle();
 @endphp
 
 <div x-data="{}"
@@ -18,41 +23,41 @@
      ]) }}
      style="{{ $colors }}">
     <div class="flex gap-3">
-        @if($getIcon())
+        @if($icon)
             <div @class([
                 'flex-shrink-0',
                 $getIconVerticalAlignment() === 'start' ? 'self-start' : 'self-center',
             ])>
                 <x-filament::icon
-                    :icon="$getIcon()"
+                    :icon="$icon"
                     :class="$iconClasses"
                 />
             </div>
         @endif
         <div class="items-center flex-1 md:flex md:justify-between space-y-3 md:space-y-0 md:gap-3">
-            @if($getTitle() || $getDescription())
+            @if($title || $description)
                 <div class="space-y-0.5">
-                    @if($getTitle())
+                    @if($title)
                         <p class="text-sm font-medium text-custom-800 dark:text-white">
-                            {{ $getTitle() }}
+                            {{ $title }}
                         </p>
                     @endif
-                    @if($getDescription())
+                    @if($description)
                         <div class="block text-sm text-custom-700 dark:text-white">
-                            {{ $getDescription() }}
+                            {{ $description }}
                         </div>
                     @endif
                 </div>
             @endif
-            @if($getActions())
+            @if($actions)
                 <div @class([
                   'flex items-center gap-3',
                     $getActionsVerticalAlignment() === 'start' ? 'self-start' : 'self-center',
                 ])>
                     <div class="flex items-center whitespace-nowrap gap-3">
-                        @if($getActions())
+                        @if($actions)
                             <div class="gap-3 flex items-center justify-start">
-                                @foreach ($getActions() as $action)
+                                @foreach ($actions as $action)
                                     @if ($action->isVisible())
                                         {{ $action }}
                                     @endif


### PR DESCRIPTION
This PR fixes an issue where in many places the same closure is evaluated multiple times. If you were to pass in a Query to that Closure, this would be evaluated multiple times (up to 3 times for `->description()`)

Simply assigning a local variable will fix this issue. 

For example:

```php

public static function configure(Schema $schema): Schema
{
    return $schema
        ->components([
            SimpleAlert::make('user_count_alert')
                ->info()
                ->title('User Statistics')
                ->description(fn () => 'Total users in system: ' . User::count()),

  ]);
}
```

Before:
<img width="2246" height="1323" alt="Screenshot from 2026-01-25 02-40-25" src="https://github.com/user-attachments/assets/e735c037-c26d-49be-9487-237b8d0ca072" />


After:
<img width="2246" height="1323" alt="Screenshot from 2026-01-25 02-40-04" src="https://github.com/user-attachments/assets/cf690725-c485-4384-8810-8e0e06653608" />
