### PR TITLE
fix: Undefinded variable `$getColor` 

### DIFF
--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -6,6 +6,8 @@
     'iconVerticalAlignment' => 'start',
     'title' => null,
     'description' => null,
+    'actions' => null,
+    'actionsVerticalAlignment' => 'center',
 ])
 
 @php
@@ -18,8 +20,8 @@
     $iconVerticalAlignment = value($getIconVerticalAlignment ?? $iconVerticalAlignment);
     $title = value($getTitle ?? $title);
     $description = value($getDescription ?? $description);
-    $actions = value($getActions ?? null);
-    $actionsVerticalAlignment = value($getActionsVerticalAlignment ?? 'center');
+    $actions = value($getActions ?? $actions);
+    $actionsVerticalAlignment = value($getActionsVerticalAlignment ?? $actionsVerticalAlignment);
 
     $colors = \Illuminate\Support\Arr::toCssStyles([
            get_color_css_variables($color, shades: [50, 100, 400, 500, 700, 800]),

--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -1,64 +1,82 @@
+@props([
+    'color' => 'gray',
+    'border' => false,
+    'icon' => null,
+    'iconAnimation' => null,
+    'iconVerticalAlignment' => 'start',
+    'title' => null,
+    'description' => null,
+])
+
 @php
     use function Filament\Support\get_color_css_variables;
 
+    $color = value($getColor ?? $color);
+    $border = value($getBorder ?? $border);
+    $icon = value($getIcon ?? $icon);
+    $iconAnimation = value($getIconAnimation ?? $iconAnimation);
+    $iconVerticalAlignment = value($getIconVerticalAlignment ?? $iconVerticalAlignment);
+    $title = value($getTitle ?? $title);
+    $description = value($getDescription ?? $description);
+    $actions = value($getActions ?? null);
+    $actionsVerticalAlignment = value($getActionsVerticalAlignment ?? 'center');
+
     $colors = \Illuminate\Support\Arr::toCssStyles([
-           get_color_css_variables($getColor(), shades: [50, 100, 400, 500, 700, 800]),
+           get_color_css_variables($color, shades: [50, 100, 400, 500, 700, 800]),
     ]);
 
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'h-5 w-5 text-custom-400',
-        $getIconAnimation(),
+        $iconAnimation,
     ]);
 @endphp
 
 <div x-data="{}"
      {{ $attributes->class([
          'filament-simple-alert rounded-md bg-custom-50 p-4 dark:bg-custom-400/10',
-         'ring-1 ring-custom-100 dark:ring-custom-500/70' => $getBorder(),
+         'ring-1 ring-custom-100 dark:ring-custom-500/70' => $border,
      ]) }}
      style="{{ $colors }}">
     <div class="flex gap-3">
-        @if($getIcon())
+        @if($icon)
             <div @class([
                 'flex-shrink-0',
-                $getIconVerticalAlignment() === 'start' ? 'self-start' : 'self-center',
+                $iconVerticalAlignment === 'start' ? 'self-start' : 'self-center',
             ])>
                 <x-filament::icon
-                    :icon="$getIcon()"
-                    :class="$iconClasses"
+                        :icon="$icon"
+                        :class="$iconClasses"
                 />
             </div>
         @endif
         <div class="items-center flex-1 md:flex md:justify-between space-y-3 md:space-y-0 md:gap-3">
-            @if($getTitle() || $getDescription())
+            @if($title || $description)
                 <div class="space-y-0.5">
-                    @if($getTitle())
+                    @if($title)
                         <p class="text-sm font-medium text-custom-800 dark:text-white">
-                            {{ $getTitle() }}
+                            {{ $title }}
                         </p>
                     @endif
-                    @if($getDescription())
+                    @if($description)
                         <div class="block text-sm text-custom-700 dark:text-white">
-                            {{ $getDescription() }}
+                            {{ $description }}
                         </div>
                     @endif
                 </div>
             @endif
-            @if($getActions())
+            @if($actions)
                 <div @class([
                   'flex items-center gap-3',
-                    $getActionsVerticalAlignment() === 'start' ? 'self-start' : 'self-center',
+                    $actionsVerticalAlignment === 'start' ? 'self-start' : 'self-center',
                 ])>
                     <div class="flex items-center whitespace-nowrap gap-3">
-                        @if($getActions())
-                            <div class="gap-3 flex items-center justify-start">
-                                @foreach ($getActions() as $action)
-                                    @if ($action->isVisible())
-                                        {{ $action }}
-                                    @endif
-                                @endforeach
-                            </div>
-                        @endif
+                        <div class="gap-3 flex items-center justify-start">
+                            @foreach ($actions as $action)
+                                @if ($action->isVisible())
+                                    {{ $action }}
+                                @endif
+                            @endforeach
+                        </div>
                     </div>
                 </div>
             @endif

--- a/resources/views/components/simple-alert.blade.php
+++ b/resources/views/components/simple-alert.blade.php
@@ -3,7 +3,7 @@
     'border' => false,
     'icon' => null,
     'iconAnimation' => null,
-    'iconVerticalAlignment' => 'start',
+    'iconVerticalAlignment' => 'center',
     'title' => null,
     'description' => null,
     'actions' => null,


### PR DESCRIPTION
This PR fixes an issue where when used as a regular blade component (outside of filament context), that would throw errors for many undefinded variables (namely all closures `$get*`) as they are not available outside of filament.

To fix this issues, we could use laravels [`value()`](https://laravel.com/docs/12.x/helpers#method-value) helper and fallback to a defined `@prop` instead.

```php
$color = value($getColor ?? $color);
```

This approach differs from the [v3](https://github.com/CodeWithDennis/filament-simple-alert/blob/3.x/resources/views/components/simple-alert-field.blade.php), and should be addresses properly in a future major release as bringing this back inline would probably introduce a breaking change?

Fixes #51 #58

Before: 
<img width="2246" height="1323" alt="Screenshot from 2026-01-25 03-08-11" src="https://github.com/user-attachments/assets/f2838429-c9e2-42a2-afae-a92f00bf29ea" />

After:
<img width="2246" height="1323" alt="Screenshot from 2026-01-25 03-07-51" src="https://github.com/user-attachments/assets/d55b45ad-6c39-49de-ad83-d23529077887" />


